### PR TITLE
Improved labling wording and only allow saving valid labelings

### DIFF
--- a/src/Tests/components/editLabelingModal.test.js
+++ b/src/Tests/components/editLabelingModal.test.js
@@ -42,7 +42,7 @@ describe('Create new labeling', () => {
     const wrapper = mount(
       <EditLabelingModal isOpen={true}></EditLabelingModal>
     );
-    expect(wrapper.contains('Add labeling')).toBe(true);
+    expect(wrapper.contains('Add Labeling Set')).toBe(true);
   });
 
   it('Create new labeling', () => {

--- a/src/components/EditLabelingModal/EditLabelingModal.js
+++ b/src/components/EditLabelingModal/EditLabelingModal.js
@@ -33,7 +33,8 @@ class EditLabelingModal extends Component {
       onSave: props.onSave,
       onDeleteLabeling: props.onDeleteLabeling,
       isNewLabeling: props.isNewLabeling,
-      deletedLabels: []
+      deletedLabels: [],
+      allowSaving: false
     };
     this.onAddLabel = this.onAddLabel.bind(this);
     this.onDeleteLabel = this.onDeleteLabel.bind(this);
@@ -43,29 +44,51 @@ class EditLabelingModal extends Component {
   }
 
   componentWillReceiveProps(props) {
-    this.setState({
-      labeling: props.labeling,
-      labels: props.labels,
-      isOpen: props.isOpen,
-      onCloseModal: props.onCloseModal,
-      onSave: props.onSave,
-      onDeleteLabeling: props.onDeleteLabeling,
-      isNewLabeling: props.isNewLabeling
-    });
+    this.setState(
+      {
+        labeling: props.labeling,
+        labels: props.labels,
+        isOpen: props.isOpen,
+        onCloseModal: props.onCloseModal,
+        onSave: props.onSave,
+        onDeleteLabeling: props.onDeleteLabeling,
+        isNewLabeling: props.isNewLabeling,
+        allowSaving: false
+      },
+      () => {
+        if (
+          typeof this.state !== 'undefined' &&
+          typeof this.state.labels !== 'undefined' &&
+          typeof this.state.labeling !== 'undefined'
+        ) {
+          this.checkAllowSaving();
+        }
+      }
+    );
   }
 
   onLabelingNameChanged(name) {
     if (this.state.isNewLabeling) {
-      this.setState({
-        labeling: Object.assign({}, this.state.labeling, { name })
-      });
+      this.setState(
+        {
+          labeling: Object.assign({}, this.state.labeling, { name })
+        },
+        () => {
+          this.checkAllowSaving();
+        }
+      );
     } else {
-      this.setState({
-        labeling: Object.assign({}, this.state.labeling, {
-          name,
-          updated: true
-        })
-      });
+      this.setState(
+        {
+          labeling: Object.assign({}, this.state.labeling, {
+            name,
+            updated: true
+          })
+        },
+        () => {
+          this.checkAllowSaving();
+        }
+      );
     }
   }
 
@@ -76,9 +99,14 @@ class EditLabelingModal extends Component {
       isNewLabel: true
     };
 
-    this.setState({
-      labels: [...this.state.labels, newLabel]
-    });
+    this.setState(
+      {
+        labels: [...this.state.labels, newLabel]
+      },
+      () => {
+        this.checkAllowSaving();
+      }
+    );
   }
 
   onDeleteLabel(labelToDelete) {
@@ -89,31 +117,48 @@ class EditLabelingModal extends Component {
     );
 
     if (labelToDelete.isNewLabel) {
-      this.setState({ labels, labeling });
-    } else {
-      this.setState({
-        labels,
-        labeling,
-        deletedLabels: [...this.state.deletedLabels, labelToDelete['_id']]
+      this.setState({ labels, labeling }, () => {
+        this.checkAllowSaving();
       });
+    } else {
+      this.setState(
+        {
+          labels,
+          labeling,
+          deletedLabels: [...this.state.deletedLabels, labelToDelete['_id']]
+        },
+        () => {
+          this.checkAllowSaving();
+        }
+      );
     }
   }
 
   onLabelNameChanged(labelToChange, name) {
     if (labelToChange.isNewLabel) {
-      this.setState({
-        labels: this.state.labels.map(label =>
-          label !== labelToChange ? label : Object.assign({}, label, { name })
-        )
-      });
+      this.setState(
+        {
+          labels: this.state.labels.map(label =>
+            label !== labelToChange ? label : Object.assign({}, label, { name })
+          )
+        },
+        () => {
+          this.checkAllowSaving();
+        }
+      );
     } else {
-      this.setState({
-        labels: this.state.labels.map(label =>
-          label !== labelToChange
-            ? label
-            : Object.assign({}, label, { name, updated: true })
-        )
-      });
+      this.setState(
+        {
+          labels: this.state.labels.map(label =>
+            label !== labelToChange
+              ? label
+              : Object.assign({}, label, { name, updated: true })
+          )
+        },
+        () => {
+          this.checkAllowSaving();
+        }
+      );
     }
   }
 
@@ -137,6 +182,22 @@ class EditLabelingModal extends Component {
         )
       });
     }
+  }
+
+  checkAllowSaving() {
+    var allowSaving = false;
+
+    for (let i = 0; i < this.state.labels.length; i++) {
+      if (this.state.labels[i].name === '') {
+        allowSaving = false;
+        break;
+      } else {
+        allowSaving = true;
+      }
+    }
+    this.setState({
+      allowSaving: allowSaving && this.state.labeling.name !== ''
+    });
   }
 
   render() {
@@ -277,6 +338,7 @@ class EditLabelingModal extends Component {
                 this.state.deletedLabels
               );
             }}
+            disabled={!this.state.allowSaving}
           >
             Save
           </Button>{' '}

--- a/src/components/EditLabelingModal/EditLabelingModal.js
+++ b/src/components/EditLabelingModal/EditLabelingModal.js
@@ -145,15 +145,16 @@ class EditLabelingModal extends Component {
         <ModalHeader>
           {this.state.labeling && this.state.labeling['_id']
             ? this.state.labeling['_id']
-            : 'Add labeling'}
+            : 'Add Labeling Set'}
         </ModalHeader>
         <ModalBody>
           <InputGroup>
             <InputGroupAddon addonType="prepend">
-              <InputGroupText>Name</InputGroupText>
+              <InputGroupText>Labeling Set</InputGroupText>
             </InputGroupAddon>
             <Input
               id="labelingName"
+              placeholder="Name"
               value={
                 this.state.labeling && this.state.labeling.name
                   ? this.state.labeling.name
@@ -242,7 +243,7 @@ class EditLabelingModal extends Component {
             block
             onClick={this.onAddLabel}
           >
-            + Add
+            + Add Label
           </Button>
           {this.state.labeling && !this.state.isNewLabeling ? (
             <div>

--- a/src/components/LabelingSelectionPanel/LabelingSelectionPanel.js
+++ b/src/components/LabelingSelectionPanel/LabelingSelectionPanel.js
@@ -77,7 +77,7 @@ class LabelingSelectionPanel extends Component {
             color="secondary"
             onClick={this.props.onAddLabeling}
           >
-            + Add
+            + Add Labeling Set
           </Button>
         </CardBody>
       </Card>

--- a/src/components/ManagementPanel/ManagementPanel.js
+++ b/src/components/ManagementPanel/ManagementPanel.js
@@ -44,6 +44,9 @@ class ManagementPanel extends Component {
     var labelsUsed =
       typeof dataset.labelings !== 'undefined' && dataset.labelings.length > 0;
 
+    console.log(dataset);
+    console.log(this.props.labelings);
+
     if (labelsUsed) {
       dataset.labelings.forEach(l => {
         labelings[l.labelingId] = [];
@@ -61,7 +64,6 @@ class ManagementPanel extends Component {
       csv += 'sensor_' + t.name + '[' + t.unit + '],';
     });
 
-    console.log(labelings);
     if (labelsUsed) {
       for (const [labelingId, _] of Object.entries(labelings)) {
         const labelingName = this.props.labelings.find(

--- a/src/routes/labelings.js
+++ b/src/routes/labelings.js
@@ -254,7 +254,7 @@ class LabelingsPage extends Component {
                 outline
                 onClick={this.onModalAddLabeling}
               >
-                + Add
+                + Add Labeling Set
               </Button>
             </Col>
           </Row>


### PR DESCRIPTION
Fixes issue "Labeling creation has ambiguous wording. #9" and also addresses the crash when trying to use a labeling without a label, resulting in a crash. 
The "save" button when creating/editing labels will now only be activated, when a valid labeling is created.